### PR TITLE
integration-test: Add automated MachSuite tests.

### DIFF
--- a/integration-test/common/conftest.py
+++ b/integration-test/common/conftest.py
@@ -1,0 +1,76 @@
+import pytest
+import os
+import tempfile
+import shutil
+import subprocess
+
+RUN_SCRIPT_FNAME = "run.sh"
+OUTPUT_DIR = "output_dir"
+SWEEP_GENERATOR = "generate_design_sweeps.py"
+
+def is_master(config):
+  """Return true we're on a master node."""
+  return not hasattr(config, 'workerinput')
+
+def pytest_addoption(parser):
+  parser.addoption("--sweep-file", action="store", help="Sweep file")
+
+def pytest_configure(config):
+  """Generate sweeps using the sweep generator.
+
+  Only the master node performs the sweep generation.
+  """
+  if is_master(config):
+    cwd = os.getcwd()
+    config.tmp_output_dir = tempfile.mkdtemp(dir=cwd)
+    _, config.tmp_sweep_file = tempfile.mkstemp(suffix=".xe", dir=cwd)
+    # Read the sweep file and update the `output_dir` field with a temp dir.
+    sweep_file = config.getoption("--sweep-file")
+    if not os.path.isabs(sweep_file):
+      sweep_file = os.path.join(cwd, sweep_file)
+    with open(sweep_file, "r") as f_in, open(config.tmp_sweep_file,
+                                             "w") as f_out:
+      fmt_key = "%%(%s)s" % OUTPUT_DIR
+      for line in f_in:
+        if fmt_key in line:
+          f_out.write(line % {OUTPUT_DIR: config.tmp_output_dir})
+        else:
+          f_out.write(line)
+    # Generate the sweeps using the generator.
+    sweeps_dir = "%s/../../sweeps" % os.environ["ALADDIN_HOME"]
+    os.chdir(sweeps_dir)
+    sweep_generator = os.path.join(sweeps_dir, SWEEP_GENERATOR)
+    process = subprocess.Popen(
+        ["python", sweep_generator, config.tmp_sweep_file],
+        stdout=True,
+        stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    assert process.returncode == 0, (
+        "Running the sweeper returned nonzero exit "
+        "code Contents of stderr:\n %s" % stderr.decode("utf-8"))
+    os.chdir(cwd)
+    # Find all the run scripts.
+    run_scripts = []
+    for root, dirs, files in os.walk(config.tmp_output_dir):
+      for f in files:
+        if f == RUN_SCRIPT_FNAME:
+          run_scripts.append(os.path.join(root, f))
+    # Set the shared `run_scripts`. This can be accessed by the workers later.
+    config.run_scripts = run_scripts
+
+def pytest_unconfigure(config):
+  if is_master(config):
+    shutil.rmtree(config.tmp_output_dir)
+    os.remove(config.tmp_sweep_file)
+
+def pytest_configure_node(node):
+  """This hook only runs on the workers to get the shared `run_scripts`."""
+  node.workerinput["run_scripts"] = node.config.run_scripts
+
+def pytest_generate_tests(metafunc):
+  if is_master(metafunc.config):
+    run_scripts = metafunc.config.run_scripts
+  else:
+    run_scripts = metafunc.config.workerinput["run_scripts"]
+  if "run_script" in metafunc.fixturenames:
+    metafunc.parametrize("run_script", run_scripts)

--- a/integration-test/common/conftest.py
+++ b/integration-test/common/conftest.py
@@ -1,8 +1,41 @@
+""" This contains pytest hook implementations.
+
+pytest will look for a conftest.py for directory-specific pytest hook
+implementations (tests in the same directory will share the hooks). All the hook
+functions have a pytest_ prefix, tests will invoke the hooks defined in
+conftest.py. Refer to https://docs.pytest.org/en/stable/reference.html for more
+details about the pytest APIs.
+
+Also a bit introduction on pytest-xdist. It's a plugin to pytest that extends
+pytest mainly for parallel test run. Simply use the "-n" command line option to
+specify the number of processes to run the tests. xdist uses a master node for
+control process and worker nodes for running actual tests. Each node will start
+a pytest session to collect the tests (they must see the tests consistent
+across all nodes), and then the tests will be distributed to all the workers.
+
+Here we implement these pytest hooks:
+- pytest_addoption: It allows the test to take in command line arguments. This
+    is called once at the beginning of a test run. We add a sweep file command
+    line option.
+- pytest_configure: It performs initial configuration. This is called after
+    command line options have been parsed. We use this hook to invoke the sweep
+    generator to create sweeps.
+- pytest_unconfigure: It's called before test run is exited. We implement this
+    to delete temporary test files.
+- pytest_configure_node: This is a pytest-xdist hook. It configures worker
+    nodes. It only runs on a worker node. We implement this to make the master
+    share the test run scripts with the workers.
+- pytest_generate_tests: This can be used to generate (multiple) parametrized
+    calls to a test function. We use the shared `run_scripts` to dynamically
+    generate tests (one for each run script).
+"""
+
 import pytest
 import os
 import tempfile
 import shutil
 import subprocess
+import six
 
 RUN_SCRIPT_FNAME = "run.sh"
 OUTPUT_DIR = "output_dir"
@@ -13,6 +46,7 @@ def is_master(config):
   return not hasattr(config, 'workerinput')
 
 def pytest_addoption(parser):
+  """Add an option for specifying the sweep file."""
   parser.addoption("--sweep-file", action="store", help="Sweep file")
 
 def pytest_configure(config):
@@ -30,24 +64,23 @@ def pytest_configure(config):
       sweep_file = os.path.join(cwd, sweep_file)
     with open(sweep_file, "r") as f_in, open(config.tmp_sweep_file,
                                              "w") as f_out:
+      f_in_content = f_in.read()
       fmt_key = "%%(%s)s" % OUTPUT_DIR
-      for line in f_in:
-        if fmt_key in line:
-          f_out.write(line % {OUTPUT_DIR: config.tmp_output_dir})
-        else:
-          f_out.write(line)
+      if fmt_key in f_in_content:
+        f_out.write(f_in_content % {OUTPUT_DIR: config.tmp_output_dir})
     # Generate the sweeps using the generator.
     sweeps_dir = "%s/../../sweeps" % os.environ["ALADDIN_HOME"]
     os.chdir(sweeps_dir)
     sweep_generator = os.path.join(sweeps_dir, SWEEP_GENERATOR)
     process = subprocess.Popen(
         ["python", sweep_generator, config.tmp_sweep_file],
-        stdout=True,
+        # Print the stdout directly.
+        stdout=None,
         stderr=subprocess.PIPE)
     _, stderr = process.communicate()
     assert process.returncode == 0, (
         "Running the sweeper returned nonzero exit "
-        "code Contents of stderr:\n %s" % stderr.decode("utf-8"))
+        "code Contents of stderr:\n %s" % six.ensure_text(stderr))
     os.chdir(cwd)
     # Find all the run scripts.
     run_scripts = []
@@ -59,6 +92,7 @@ def pytest_configure(config):
     config.run_scripts = run_scripts
 
 def pytest_unconfigure(config):
+  """Delete test temporary files."""
   if is_master(config):
     shutil.rmtree(config.tmp_output_dir)
     os.remove(config.tmp_sweep_file)
@@ -68,6 +102,7 @@ def pytest_configure_node(node):
   node.workerinput["run_scripts"] = node.config.run_scripts
 
 def pytest_generate_tests(metafunc):
+  """Generate a test for each run script in the shared `run_scripts`."""
   if is_master(metafunc.config):
     run_scripts = metafunc.config.run_scripts
   else:

--- a/integration-test/common/machsuite_cache.xe
+++ b/integration-test/common/machsuite_cache.xe
@@ -1,0 +1,22 @@
+# This imports the Gem5DesignSweep type into global scope.
+use benchmarks.designsweeptypes.Gem5DesignSweep
+
+begin Gem5DesignSweep single
+
+use benchmarks.machsuite.*
+
+generate configs
+generate trace
+generate gem5_binary
+
+# Set parameters.
+set output_dir "%(output_dir)s" # A comment
+set source_dir "../src/aladdin/MachSuite"
+set simulator "gem5-cpu"
+set memory_type "cache"
+
+sweep cycle_time from 1 to 3
+
+source "../../../../sweeps/benchmarks/machsuite_constants.xe"
+
+end single

--- a/integration-test/common/machsuite_dma.xe
+++ b/integration-test/common/machsuite_dma.xe
@@ -1,0 +1,22 @@
+# This imports the Gem5DesignSweep type into global scope.
+use benchmarks.designsweeptypes.Gem5DesignSweep
+
+begin Gem5DesignSweep single
+
+use benchmarks.machsuite.*
+
+generate configs
+generate dma_trace
+generate gem5_binary
+
+# Set parameters.
+set output_dir "%(output_dir)s" # A comment
+set source_dir "../src/aladdin/MachSuite"
+set simulator "gem5-cpu"
+set memory_type "spad"
+
+sweep cycle_time from 1 to 3
+
+source "../../../../sweeps/benchmarks/machsuite_constants.xe"
+
+end single

--- a/integration-test/common/run_sweep_tests.py
+++ b/integration-test/common/run_sweep_tests.py
@@ -1,0 +1,13 @@
+import pytest
+import os
+import subprocess
+
+def test_point(run_script):
+  process = subprocess.Popen(["bash", os.path.basename(run_script)],
+                             cwd=os.path.dirname(run_script),
+                             stdout=True,
+                             stderr=subprocess.PIPE)
+  _, stderr = process.communicate()
+  assert process.returncode == 0, (
+      "Running a sweep point returned nonzero exit code! Contents of stderr:\n "
+      "%s" % stderr.decode("utf-8"))

--- a/integration-test/common/run_sweep_tests.py
+++ b/integration-test/common/run_sweep_tests.py
@@ -5,9 +5,9 @@ import six
 def test_point(run_script):
   process = subprocess.Popen(["bash", os.path.basename(run_script)],
                              cwd=os.path.dirname(run_script),
-                             stdout=None,
+                             stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
-  _, stderr = process.communicate()
+  stdout, stderr = process.communicate()
   assert process.returncode == 0, (
-      "Running a sweep point returned nonzero exit code! Contents of stderr:\n "
-      "%s" % six.ensure_text(stderr))
+      "Running a sweep point returned nonzero exit code! Contents of output:\n "
+      "%s\n%s" % (six.ensure_text(stdout), six.ensure_text(stderr)))

--- a/integration-test/common/run_sweep_tests.py
+++ b/integration-test/common/run_sweep_tests.py
@@ -1,13 +1,13 @@
-import pytest
 import os
 import subprocess
+import six
 
 def test_point(run_script):
   process = subprocess.Popen(["bash", os.path.basename(run_script)],
                              cwd=os.path.dirname(run_script),
-                             stdout=True,
+                             stdout=None,
                              stderr=subprocess.PIPE)
   _, stderr = process.communicate()
   assert process.returncode == 0, (
       "Running a sweep point returned nonzero exit code! Contents of stderr:\n "
-      "%s" % stderr.decode("utf-8"))
+      "%s" % six.ensure_text(stderr))


### PR DESCRIPTION
We previously had to manually use the sweep generator and run the
sweeps. This adds automated pytests for running MachSuite benchmarks.

This was initially written in unittest, but changed to pytest because
it offers a much easier way to enable dynamic test generation. Also,
pytest-xdist plugin is used to run the tests in parallel. We can run the
tests with 8 process using the following:

`pytest run_sweep_tests.py -n 8 --sweep-file=machesuite_dma.xe`

TESTED=integration-test