### PR TITLE
 Fix insertion to inflight_dma_nodes

### DIFF
--- a/gem5/HybridDatapath.cpp
+++ b/gem5/HybridDatapath.cpp
@@ -516,7 +516,16 @@ bool HybridDatapath::handleDmaMemoryOp(ExecNode* node) {
 
   MemAccessStatus status = Invalid;
   unsigned node_id = node->get_node_id();
+    
   if (inflight_dma_nodes.find(node_id) == inflight_dma_nodes.end()) {
+    /* Add node to inflight_dma_nodes if the queue size < maxInflightNodes and
+     * start processing it. Otherwise, return false and try adding later after
+     * earlier nodes finish.
+     * 
+     * We do this to make sure inflight_dma_nodes only contains nodes that are
+     * actually inflight and being processed. Not doing this might lead to no
+     * nodes being processed, preventing the system from making progress.
+     */
     if (inflight_dma_nodes.size() < maxInflightNodes)
       inflight_dma_nodes[node_id] = status;
     else
@@ -524,7 +533,9 @@ bool HybridDatapath::handleDmaMemoryOp(ExecNode* node) {
   } else {
     status = inflight_dma_nodes.at(node_id);
   }
+    
   HostMemAccess* mem_access = node->get_host_mem_access();
+    
   if (status == Invalid) {
     /* A DMA load needs to be preceded by a cache flush of the buffer being
      * sent, while a DMA store needs to be preceded by a cache invalidate of the


### PR DESCRIPTION
When the queue `inflight_dma_nodes` is full and more than `maxInflightNodes` new DMA nodes are executed, the new requests will wait indefinitely since the condition `inflight_dma_nodes.size() < maxInflightNodes` will never evaluate to true.

This commit changes the logic so that new nodes are only queued when `inflight_dma_nodes` has space.