### PR TITLE
tests: Add CircleCI configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+orbs:
+  docker: circleci/docker@1.3.0
+jobs:
+  build:
+    docker:
+      - image: xyzsam/smaug:latest
+    environment:
+      ALADDIN_HOME: /root/project
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            cd common
+            make all -j2
+            cd ../unit-test
+            make all -j4
+      - run:
+          name: Run unit tests
+          environment:
+            TEST_REPORT_DIR: ~/aladdin-junit-report-dir
+          command: |
+            cd unit-test
+            make junit_test
+      - store_test_results:
+          path: ~/aladdin-junit-report-dir

--- a/unit-test/Makefile
+++ b/unit-test/Makefile
@@ -28,7 +28,7 @@ LFLAGS += -lmysqlcppconn
 CFLAGS += -I$(MYSQL_HOME)/include -DUSE_DB
 endif
 
-TEST_REPORT_DIR = report_dir
+TEST_REPORT_DIR ?= report_dir
 
 COMMON_OBJS = catch_common.o
 TEST_OBJS = test_dddg_generation.o test_init_base_address.o \


### PR DESCRIPTION
TravisCI moved from travis-ci.org to travis-ci.com, which now requires payment information even for the free tier. Let's just not bother and move everything over to CircleCI instead.

Includes some improvements to integration testing.